### PR TITLE
Support browserify

### DIFF
--- a/fuzzy-query.js
+++ b/fuzzy-query.js
@@ -786,6 +786,6 @@ var FQ = function() {
   }
 };
 
-if (typeof window === 'undefined') {
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = FQ;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuzzy-query",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Intuitive query to select HTML element and operate input action.",
   "main": "fuzzy-query.js",
   "scripts": {


### PR DESCRIPTION
Browserify needs `module.exports`, but it is called by browser, so it has `window`